### PR TITLE
Fix 400 Client error 

### DIFF
--- a/app.py
+++ b/app.py
@@ -49,7 +49,7 @@ def callback():
     try:
         # Retrieve code and request access token
         token_res = requests.post(
-            "{url}/token".format(url=base_oauth_url), params=token_params
+            "{url}/token".format(url=base_oauth_url), data=token_params
         )
 
         token_res.raise_for_status()


### PR DESCRIPTION
I got: 
```
400 Client Error: Bad Request for url: h ttps://identity.pagerduty.com/oauth/token?client_id=[****]&client_secret=[****]&redirect_uri=http%3A%2F%2Flocalhost%3A5000%2Fcallback&grant_type=authorization_code&code=[****]
```

With error body: 
```
{"error":"invalid_request","error_description":"grant_type is missing"}
```

Fixed it by sending params in the body as specified at: https://developer.pagerduty.com/docs/user-oauth-token-via-code-grant